### PR TITLE
Rename API_AUTH_TOKEN to AUTH_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ gem install clinic_searcher, --source https://github.com/alexjabf/clinic_searc
 Before using the gem, ensure you have the following environment variables set up:
 
 - `API_ENDPOINT`: The Rails API endpoint where the gem will send requests.
-- `API_AUTH_TOKEN`: The authentication token used in the `X-Auth-Token` header for the request.
+- `AUTH_TOKEN`: The authentication token used in the `X-Auth-Token` header for the request.
 - `RATIO_DISTANCE` (optional): The default search radius in miles. Defaults to 20 if not set.
 
 ## Usage

--- a/lib/clinic_searcher.rb
+++ b/lib/clinic_searcher.rb
@@ -7,7 +7,7 @@ require "geocoder"
 module ClinicSearcher
   class Error < StandardError
     def message
-      "Please set up the environment variables for API_ENDPOINT and API_AUTH_TOKEN." \
+      "Please set up the environment variables for API_ENDPOINT and AUTH_TOKEN." \
         " Additionally, you may configure a RATIO_DISTANCE variable to specify the search radius."
     end
   end
@@ -31,7 +31,7 @@ module ClinicSearcher
     end
 
     def auth_token
-      ENV.fetch("API_AUTH_TOKEN", nil)
+      ENV.fetch("AUTH_TOKEN", nil)
     end
 
     def ratio_distance
@@ -40,7 +40,7 @@ module ClinicSearcher
 
     def missing_required_env_variables?
       # Check if the required environment variables are set, return true if they are missing
-      ENV["API_ENDPOINT"].nil? || ENV["API_AUTH_TOKEN"].nil?
+      ENV["API_ENDPOINT"].nil? || ENV["AUTH_TOKEN"].nil?
     end
   end
 end

--- a/spec/clinic_searcher_spec.rb
+++ b/spec/clinic_searcher_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ClinicSearcher do
     context "when required environment variables are not set" do
       before do
         allow(ENV).to receive(:[]).with("API_ENDPOINT").and_return(nil)
-        allow(ENV).to receive(:[]).with("API_AUTH_TOKEN").and_return(nil)
+        allow(ENV).to receive(:[]).with("AUTH_TOKEN").and_return(nil)
       end
 
       it "raises an error with an appropriate message" do
@@ -23,7 +23,7 @@ RSpec.describe ClinicSearcher do
     context "when required environment variables are set" do
       before do
         allow(ENV).to receive(:[]).with("API_ENDPOINT").and_return("https://example.com/api")
-        allow(ENV).to receive(:[]).with("API_AUTH_TOKEN").and_return("sample-auth-token")
+        allow(ENV).to receive(:[]).with("AUTH_TOKEN").and_return("sample-auth-token")
         allow(HTTParty).to receive(:get).and_return(double("response", parsed_response: "OK"))
       end
 


### PR DESCRIPTION
We have renamed the API_AUTH_TOKEN environment variable to AUTH_TOKEN. This change ensures that the environment variable names are different on both the API and the gem side. It allows us to test different values for each side and reproduce the "unauthorized" error on the API side if needed.